### PR TITLE
Add Debian assets and cross-compilation config, update readme

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,4 @@
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+objcopy = { path ="aarch64-linux-gnu-objcopy" }
+strip = { path ="aarch64-linux-gnu-strip" }

--- a/README.md
+++ b/README.md
@@ -45,9 +45,44 @@ OPTIONS:
 
 `peach-monitor` defines warning and critical thresholds and corresponding alert flags for total network data traffic. The critical threshold may allow a disable-network feature in future implementations of `peach-monitor`.
 
+### Debian Packaging
+
+A `systemd` service file and Debian maintainer scripts are included in the `debian` directory, allowing `peach-monitor` to be easily bundled as a Debian package (`.deb`). The `cargo-deb` [crate](https://crates.io/crates/cargo-deb) can be used to achieve this.
+
+Install `cargo-deb`:
+
+`cargo install cargo-deb`
+
+Move into the repo:
+
+`cd peach-monitor`
+
+Build the package:
+
+`cargo deb`
+
+The output will be written to `target/debian/peach-monitor_0.1.0_arm64.deb` (or similar).
+
+Build the package (aarch64):
+
+`cargo deb --target aarch64-unknown-linux-gnu`
+
+Install the package as follows:
+
+`sudo dpkg -i target/debian/peach-monitor_0.1.0_arm64.deb`
+
+The service will be automatically enabled and started.
+
+Uninstall the service:
+
+`sudo apt-get remove peach-monitor`
+
+Remove configuration files (not removed with `apt-get remove`):
+
+`sudo apt-get purge peach-monitor`
+
 ### Roadmap
 
-- Add Debian packaging  
 - Add disk-usage tracking and alerts  
 
 ### Licensing

--- a/debian/peach-monitor.service
+++ b/debian/peach-monitor.service
@@ -1,0 +1,29 @@
+[Unit]
+Description=Monitor network data usage and set alert flags based on user-defined thresholds.
+
+[Service]
+Type=simple
+User=peach-monitor
+Environment="RUST_LOG=error"
+ExecStart=/usr/bin/peach-monitor
+Restart=always
+CapabilityBoundingSet=~CAP_SYS_ADMIN CAP_SYS_PTRACE CAP_SYS_BOOT CAP_SYS_TIME CAP_KILL CAP_WAKE_ALARM CAP_LINUX_IMMUTABLE CAP_BLOCK_SUSPEND CAP_LEASE CAP_SYS_NICE CAP_SYS_RESOURCE CAP_RAWIO CAP_CHOWN CAP_FSETID CAP_SETFCAP CAP_DAC_* CAP_FOWNER CAP_IPC_OWNER CAP_SETUID CAP_SETGID CAP_SETPCAP CAP_AUDIT_*
+InaccessibleDirectories=/home
+IPAddressDeny=~127.0.0.1
+LockPersonality=yes
+NoNewPrivileges=yes
+PrivateTmp=yes
+PrivateUsers=yes
+ProtectControlGroups=yes
+ProtectDevices=yes
+ProtectHome=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectSystem=yes
+ReadOnlyDirectories=/var
+RestrictAddressFamilies=~AF_INET6 AF_UNIX
+RestrictNamespaces=~CLONE_NEWUSER
+SystemCallFilter=~@reboot @clock @debug @module @mount @swap @resources @privileged
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# This will only remove masks created by d-s-h on package removal.
+deb-systemd-helper unmask peach-monitor.service > /dev/null || true
+
+# was-enabled defaults to true, so new installations run enable.
+if deb-systemd-helper --quiet was-enabled peach-monitor.service
+then
+	# Enables the unit on first installation, creates new
+	# symlinks on upgrades if the unit file has changed.
+	deb-systemd-helper enable peach-monitor.service > /dev/null || true
+	deb-systemd-invoke start peach-monitor
+else
+	# Update the statefile to add new symlinks (if any), which need to be
+	# cleaned up on purge. Also remove old symlinks.
+	deb-systemd-helper update-state peach-monitor.service > /dev/null || true
+fi

--- a/debian/postrm
+++ b/debian/postrm
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# In case this system is running systemd, we make systemd reload the unit files
+# to pick up changes.
+if [ -d /run/systemd/system ] ; then
+	systemctl --system daemon-reload > /dev/null || true
+fi
+
+if [ "$1" = "remove" ]; then
+	if [ -x "/usr/bin/deb-systemd-helper" ]; then
+		deb-systemd-helper mask peach-monitor.service > /dev/null
+	fi
+fi

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+deb-systemd-invoke stop peach-monitor > /dev/null || true


### PR DESCRIPTION
Adds Debian maintainer scripts and systemd service file to allow .deb packaging of the microservice.

A local configuration file has also been added to allow cargo to cross-compile the microservice for aarch64 architecture.

Readme has been updated to reflect these changes (now includes Debian packaging instructions).